### PR TITLE
Use window when defined for global namespace

### DIFF
--- a/lib/animate.js
+++ b/lib/animate.js
@@ -34,7 +34,7 @@
         factory((root.animate = {}));
     }
 }(this, function (exports) {
-    var global = this;
+    var global = typeof window === 'undefined' ? this : window
     var time = Date.now || function () {
         return +new Date();
     };


### PR DESCRIPTION
We hit a snag building this module with Webpack where `this` was referencing an empty object. This commit checks for the presence of `window` before referring to `this`.

This doesn't feel _awesome_, any thoughts here?
